### PR TITLE
fix: add default for log files if config is not set

### DIFF
--- a/lib/application.ex
+++ b/lib/application.ex
@@ -8,7 +8,7 @@ defmodule LogflareAgent.Application do
   def start(_type, _args) do
     import Supervisor.Spec
 
-    log_files = Application.get_env(:logflare_agent, :sources)
+    log_files = Application.get_env(:logflare_agent, :sources, [])
 
     children =
       Enum.map(


### PR DESCRIPTION
adds default value if config is not set.

TODO is from [here](https://github.com/Logflare/logflare/blob/17c1b805c9c8448e2d5ba8c5e3ec1ef3c0aae937/config/config.exs#L89)